### PR TITLE
Fix script snippet insertion

### DIFF
--- a/index.html
+++ b/index.html
@@ -418,12 +418,11 @@
       }
       if (!resp.ok) throw new Error(await resp.text());
       // Affiche le snippet de script à intégrer
-      const snippet = 
-  `<script 
-    src="https://chatbot-vocal-frontend.onrender.com/ChatbotWidget.js"
-    data-client-id="${clientId}"
-    data-backend-url="${backendUrl}">
-  </script>`;
+        const snippet =
+    `<script
+      src="https://chatbot-vocal-frontend.onrender.com/ChatbotWidget.js"
+      data-client-id="${clientId}"
+      data-backend-url="${backendUrl}"><\/script>`;
       scriptSnippet.textContent = snippet;
       scriptResult.style.display = "block";
       statusDiv.style.color = "#13e580";


### PR DESCRIPTION
## Summary
- avoid closing `<script>` tag prematurely when generating widget snippet in index.html

## Testing
- `npm test` *(fails: package.json not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d1663e308326a9ead1b0f9dc7b62